### PR TITLE
fix: add missing certificate name field when gardener registration

### DIFF
--- a/src/pages/authentication/SignUpPage.jsx
+++ b/src/pages/authentication/SignUpPage.jsx
@@ -183,6 +183,7 @@ function SignUpPage() {
       city: formData.city,
       province: formData.province,
       postalCode: formData.postalCode,
+      certName: formData.certName,
     };
 
     try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gardener sign-up now captures a certification name, enabling more complete profiles and improved representation of professional credentials.
  * Stored certification details may be reflected in profile and related views where applicable.
  * Existing sign-up steps and behavior remain unchanged aside from the added certification field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->